### PR TITLE
LICENSE: Add reference to external dependency of sfpi-gcc

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -190,7 +190,9 @@
 
 Third-Party Dependencies:
 
-The following dependencies are utilized by this project:
+The following separate and independent dependencies are utilized by this
+project but are not distributed as part of the software and are subject
+to their own license terms listed as follows:
 
 - sfpi-gcc - https://github.com/tenstorrent-metal/sfpi-rel/blob/master/LICENSE and https://github.com/tenstorrent-metal/sfpi-rel/blob/master/compiler/LICENSE
 


### PR DESCRIPTION
* LICENSE: Add reference to external dependency of sfpi-gcc

(cherry picked from commit 2bc9e10d68064ce953d770584326e26bb827cf94)